### PR TITLE
App registration script no longer works

### DIFF
--- a/src/scripts/appregistrationcli.http
+++ b/src/scripts/appregistrationcli.http
@@ -13,7 +13,7 @@
 ### Define app registration name, etc.
 appregname=myappregtest1
 clientid=$(az ad app create --display-name $appregname --query appId --output tsv)
-objectid=$(az ad app show --id $clientid --query objectId --output tsv)
+objectid=$(az ad app show --id $clientid --query id --output tsv)
 
 #Remove api permissions: disable default exposed scope first
 default_scope=$(az ad app show --id $clientid | jq '.oauth2Permissions[0].isEnabled = false' | jq -r '.oauth2Permissions')


### PR DESCRIPTION
There appears to have been changes to the ad app syntax/format, objectid no longer exists, oath2Permissions also does not exist.  Is it possible to just document the configuration via portal steps in our "Get started" document? - https://docs.microsoft.com/en-us/azure/healthcare-apis/fhir/get-started-with-fhir#create-a-fhir-service-in-the-workspace

Having customers run a post-ARM template script for deployment to configure while useful, doesn't capture steps necessary to manually reproduce easily (like the app registration step here).