### PR TITLE
fixed url references

### DIFF
--- a/src/azuredatabricks-deltalake/README.md
+++ b/src/azuredatabricks-deltalake/README.md
@@ -18,7 +18,7 @@ For this sample, we will be building a simple Lakehouse exploring a single use c
 
 Click the button below to launch Azure and deploy this sample. Open it in a new tab so you can keep referencing this readme.
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fhealthcare-apis-samples%2Fmain%2Fsrc%2Fdatabricks-deltalake%2Finfra%2Fazuredeploy.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fhealthcare-apis-samples%2Fmain%2Fsrc%2Fazuredatabricks-deltalake%2Finfra%2Fazuredeploy.json)
 
 
 ## Looking around at what we deployed

--- a/src/azuredatabricks-deltalake/infra/scripts/setup-databricks.sh
+++ b/src/azuredatabricks-deltalake/infra/scripts/setup-databricks.sh
@@ -45,9 +45,9 @@ printf "\n Secret adls-access-client-id created"
 printf "\nStaging notebooks..."
 mkdir -p notebooks && cd notebooks
 curl -L \
-    -O "https://raw.githubusercontent.com/microsoft/healthcare-apis-samples/main/src/databricks-deltalake/notebooks/Creating-a-Patient-Delta-Table-with-Auto-Loader.ipynb"
+    -O "https://raw.githubusercontent.com/microsoft/healthcare-apis-samples/main/src/azuredatabricks-deltalake/notebooks/Creating-a-Patient-Delta-Table-with-Auto-Loader.ipynb"
 curl -L \
-    -O "https://raw.githubusercontent.com/microsoft/healthcare-apis-samples/main/src/databricks-deltalake/notebooks/FHIR-To-Databricks-Delta.ipynb"
+    -O "https://raw.githubusercontent.com/microsoft/healthcare-apis-samples/main/src/azuredatabricks-deltalake/notebooks/FHIR-To-Databricks-Delta.ipynb"
 cd -
 
 printf "\nUploading notebooks..."


### PR DESCRIPTION
fixed issue with url refrences to the deploy template and notebooks as reported in this issue: 
https://github.com/microsoft/healthcare-apis-samples/issues/50
